### PR TITLE
fix: remove log line in prebuild-file-path.ts

### DIFF
--- a/src/prebuild-file-path.ts
+++ b/src/prebuild-file-path.ts
@@ -18,5 +18,4 @@ function prebuildName(): string {
 
 const pathToBuild = path.resolve(__dirname, `../prebuilds/${os.platform()}-${os.arch()}/${prebuildName()}`);
 
-console.log('prebuild-file-path:', pathToBuild);
 export const ptyPath: string | null = fs.existsSync(pathToBuild) ? pathToBuild : null;


### PR DESCRIPTION
## :recycle: Current situation

Currently importing this module always logs a message about the `prebuild-file-path`.

That's something we don't necessarily want to always expose to users. 

## :bulb: Proposed solution

Remove the log line

## :gear: Release Notes

* Removes `prebuild-file-path: xxx` console.log line (Fixes https://github.com/homebridge/node-pty-prebuilt-multiarch/issues/32)
