### PR TITLE
nan: Use direct GitHub tarball url to remove dependency on git cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "nan": "github:ajgassner/nan#electron-29-workaround",
+        "nan": "https://github.com/ajgassner/nan/tarball/electron-29-workaround",
         "prebuild-install": "^7.1.2"
       },
       "devDependencies": {
@@ -1642,7 +1642,8 @@
     },
     "node_modules/nan": {
       "version": "2.18.0",
-      "resolved": "git+ssh://git@github.com/ajgassner/nan.git#f4933dedce0fb160927ffe5d7896b33ef461f17c",
+      "resolved": "https://github.com/ajgassner/nan/tarball/electron-29-workaround",
+      "integrity": "sha512-PUBG+nAPa4kbiEB4hqlkzPioZ2iBcE0eqsRM0vMo/80ZMPMkROI9vU72xMsRK5YeVrjk2Z8frhReLkqU4PUK/Q==",
       "license": "MIT"
     },
     "node_modules/natural-compare": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "nan": "github:ajgassner/nan#electron-29-workaround",
+    "nan": "https://github.com/ajgassner/nan/tarball/electron-29-workaround",
     "prebuild-install": "^7.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## :recycle: Current situation

*Describe the current situation. Explain current problems, if there are any. Be as descriptive as possible (e.g., including examples or code snippets).*

[Scrypted](https://github.com/koush/scrypted) installs `@homebridge/node-pty-prebuilt-multiarch` inside a Docker image that does not have the `git` cli tool installed. With the recent 0.11.13 release and #40, the `nan` dependency now points to a GitHub repo, which npm will try to download by spawning `git`. This gives the following error:

```
root@host:/server# npm i @homebridge/node-pty-prebuilt-multiarch@0.11.13
npm ERR! code ENOENT
npm ERR! syscall spawn git
npm ERR! path git
npm ERR! errno -2
npm ERR! enoent An unknown git error occurred
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2024-03-14T16_24_04_701Z-debug-0.log
```

## :bulb: Proposed solution

*Describe the proposed solution and changes. How does it affect the project? How does it affect the internal structure (e.g., refactorings)?*

Replace the npm version pointer to an https direct link to the target repo tarball to drop the dependency on `git`.

## :gear: Release Notes

*Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features.*

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

No changes to the user.

### Testing

*Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*

No tests added.

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*
