### PR TITLE
feat: support node abi 127 (Node v22)

### DIFF
--- a/.github/workflows/Prepare prebuild environment.yml
+++ b/.github/workflows/Prepare prebuild environment.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   oldNodeBuildTargets: -t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.1 -t 18.0.0
-  nodeBuildTargets: -t 19.0.0 -t 20.0.0 -t 21.0.0
+  nodeBuildTargets: -t 19.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0
   oldElectronBuildTargets: -t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.2 -t 15.0.0 -t 16.0.0 -t 17.0.0 -t 18.0.0 -t 19.0.0
   electronBuildTargets: -t 20.0.0 -t 21.0.0 -t 22.0.0 -t 23.0.0 -t 24.0.0 -t 25.0.0 -t 26.0.0 -t 27.0.0 -t 28.0.0 -t 29.0.0
   winIA32nodeBuildTargets: -t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.1
@@ -276,7 +276,7 @@ jobs:
         run: |
           python3 -m pip install packaging setuptools
           npm ci --ignore-scripts
-          env JOBS=max node .prebuild/prebuild.js ${oldNodeBuildTargets} ${nodeBuildTargets} 
+          env JOBS=max node .prebuild/prebuild.js ${oldNodeBuildTargets} ${nodeBuildTargets}
           env JOBS=max node .prebuild/electron.js ${oldElectronBuildTargets} ${electronBuildTargets}
       #       buildify doesn't work on Mac due to missing spawn_helper
       #      env JOBS=max node .prebuild/buildify.js

--- a/.prebuild/abi_registry.json
+++ b/.prebuild/abi_registry.json
@@ -270,5 +270,12 @@
     "lts": false,
     "future": true,
     "abi": "120"
+  },
+  {
+    "runtime": "node",
+    "target": "22.0.0",
+    "lts": false,
+    "future": true,
+    "abi": "127"
   }
 ]

--- a/.prebuild/build.sh
+++ b/.prebuild/build.sh
@@ -31,8 +31,8 @@ echo
 #node .prebuild/build.js
 env JOBS=max node $*
 echo
-#env JOBS=max node .prebuild/prebuild.js -t 19.0.0 -t 20.0.0 -t 21.0.0
-#env JOBS=max node .prebuild/prebuildify.js -t 19.0.0 -t 20.0.0 -t 21.0.0
+#env JOBS=max node .prebuild/prebuild.js -t 19.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0
+#env JOBS=max node .prebuild/prebuildify.js -t 19.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0
 
 #env JOBS=max node .prebuild/prebuild.js -t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.1 -t 18.0.0
 #env JOBS=max node .prebuild/prebuildify.js -t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.1 -t 18.0.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
-# @homebridge/node-pty-prebuilt-multiarch
+<p align="center">
+  <a href="https://homebridge.io"><img src="https://raw.githubusercontent.com/homebridge/branding/latest/logos/homebridge-color-round-stylized.png" height="140"></a>
+</p>
+<span align="center">
 
+# node-pty-prebuilt-multiarch
+
+[![npm](https://badgen.net/npm/v/@homebridge/node-pty-prebuilt-multiarch/latest)](https://www.npmjs.com/package/@homebridge/node-pty-prebuilt-multiarch)
+[![npm](https://badgen.net/npm/dt/@homebridge/node-pty-prebuilt-multiarch?label=downloads)](https://www.npmjs.com/package/@homebridge/node-pty-prebuilt-multiarch)
 ![Prebuild Binaries](https://github.com/homebridge/node-pty-prebuilt-multiarch/workflows/Build%20and%20Test/badge.svg)
+[![Discord](https://badgen.net/discord/online-members/C87Pvq3?icon=discord&label=discord)](https://discord.gg/C87Pvq3)
+
+</span>
 
 This project is a parallel fork of [`node-pty`](https://github.com/Microsoft/node-pty) providing prebuilt packages for certain Node.js and Electron versions.
 
@@ -8,40 +18,48 @@ Inspired by [daviwil/node-pty-prebuilt](https://github.com/daviwil/node-pty-preb
 
 ## Usage
 
-Thanks to the excellent [`prebuild`](https://github.com/prebuild/prebuild), [`prebuild-install`](https://github.com/prebuild/prebuild) modules, and [`prebuildify`](https://github.com/prebuild/prebuildify) using this module is extremely easy.  You merely have to change your `node-pty` dependency to `@homebridge/node-pty-prebuilt-multiarch` and then change any `require` statements in your code from `require('node-pty')` to `require('@homebridge/node-pty-prebuilt-multiarch')`.
+Thanks to the excellent [`prebuild`](https://github.com/prebuild/prebuild), [`prebuild-install`](https://github.com/prebuild/prebuild) modules, and [`prebuildify`](https://github.com/prebuild/prebuildify) using this module is extremely easy.
+You merely have to change your `node-pty` dependency to `@homebridge/node-pty-prebuilt-multiarch` and then change any `require` statements in your code from `require('node-pty')` to `require('@homebridge/node-pty-prebuilt-multiarch')`.
 
-> **NOTE**: We started shipping prebuilds as of node-pty version 0.8.1, no prior versions are provided!  If you were using an earlier version of `node-pty` you will need to update your code to account for any API changes that may have occurred.
+> **NOTE**: We started shipping prebuilds as of node-pty version 0.8.1, no prior versions are provided!
+> If you were using an earlier version of `node-pty` you will need to update your code to account for any API changes that may have occurred.
 
 ## How It Works
 
-We maintain a parallel fork of the `node-pty` codebase that will be updated as new releases are shipped.  When we merge new updates to the code into the `prebuilt-multiarch` branch, new prebuilt packages for our supported Node.js and Electron versions are updated to the corresponding [GitHub release](https://github.com/homebridge/node-pty-prebuilt-multiarch/releases).
+We maintain a parallel fork of the `node-pty` codebase that will be updated as new releases are shipped.
+When we merge new updates to the code into the `prebuilt-multiarch` branch, new prebuilt packages for our supported Node.js and Electron versions are updated to the corresponding [GitHub release](https://github.com/homebridge/node-pty-prebuilt-multiarch/releases).
 
-When `@homebridge/node-pty-prebuilt-multiarch` is installed as a package dependency, the install script checks to see if there's a prebuilt package on this repo for the OS, ABI version, and architecture of the current process and then downloads it, extracting it into the module path.  If a corresponding prebuilt package is not found, `node-gyp` is invoked to build the package for the current platform.
+When `@homebridge/node-pty-prebuilt-multiarch` is installed as a package dependency, the installation script checks to see if there's a prebuilt package on this repo for the OS, ABI version, and architecture of the current process and then downloads it, extracting it into the module path.
+If a corresponding prebuilt package is not found, `node-gyp` is invoked to build the package for the current platform.
 
 ## Prebuilt Versions
 
-| OS              | Architectures               |
-| --------------- |-----------------------------|
-| macOS           | x64, arm64                  |
-| Linux (glibc)   | ia32, x64, armv6, aarch64   |
-| Linux (musl)    | x64, armv6, aarch64         |
-| Windows         | ia32, x64                   |
+| OS            | Architectures             |
+|---------------|---------------------------|
+| macOS         | x64, arm64                |
+| Linux (glibc) | ia32, x64, armv6, aarch64 |
+| Linux (musl)  | x64, armv6, aarch64       |
+| Windows       | ia32, x64                 |
 
-*We only provide prebuilt binaries for Node.js 10 and Electron 5.0.0 or higher.
+We only provide prebuilt binaries for Node.js 10 and Electron 5.0.0 or higher.
 
 ## Build / Package
 
 Please note releasing this package uses GitHub actions.
 
-This flows takes the branch selected from the workflow start drop down, and creates a GitHub and NPM Release containing the prebuild artifacts.  The version of the Release comes from the package.json, and in the case of a BETA release automatically appends the beta release version.  During processing it leverages a branch called `release-candidate` as a holding area for prebuilds.
+This flows takes the branch selected from the workflow start drop down, and creates a GitHub and NPM Release containing the prebuild artifacts.
+The version of the Release comes from the package.json, and in the case of a BETA release automatically appends the beta release version.
+During processing, it leverages a branch called `release-candidate` as a holding area for prebuilds.
 
-When running the job, most times a couple of the instances of the sub step `Commit & Push Changes` within `Prebuild NPM and GitHub Release artifacts` fails.  When this occurs just re-run.  This is due to concurency issues between the steps and github.  A typicall run has 3-4 steps fail.
+When running the job, most times a couple of the instances of the sub step `Commit & Push Changes` within `Prebuild NPM and GitHub Release artifacts` fails.
+When this occurs just re-run. This is due to concurrency issues between the steps and GitHub.
+A typical run has 3-4 steps fail.
 
-1. Create branch `release-candidate` if not existing ( The script deletes it before starting and will fail if it isn't present ).
-2. Start MacOS ARM 64 local runner
+1. Create branch `release-candidate` if not existing (the script deletes it before starting and will fail if it isn't present)
+2. Start macOS ARM 64 local runner
 3. Ensure version tag within package.json reflects version you want to publish, please note beta tags are added by the action.
-4. Run Action `Run prebuild's and Create GitHub and NPM release`, and select branch you wish to publish, and if it needs to be BETA tagged and versioned.
-5. This will run for about an hour, and create a github release with the prebuild artifacts attached, and a npm release with the prebuild artifacts attached.
+4. Run Action `Run prebuild's and Create GitHub and NPM release`, and select branch you wish to publish, and if it needs to be BETA tagged and versioned
+5. This will run for about an hour, and create a GitHub release with the prebuild artifacts attached, and a npm release with the prebuild artifacts attached
 
 ## License
 

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 export oldNodeBuildTargets='-t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.1 -t 18.0.0'
-export nodeBuildTargets='-t 19.0.0 -t 20.0.0 -t 21.0.0'
+export nodeBuildTargets='-t 19.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0'
 
 export oldElectronBuildTargets='-t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.0 -t 18.0.0 -t 19.0.0'
 export electronBuildTargets='-t 20.0.0 -t 21.0.0 -t 22.0.0 -t 23.0.0 -t 24.0.0 -t 25.0.0 -t 26.0.0 -t 27.0.0 -t 28.0.0'


### PR DESCRIPTION
## :recycle: Current situation

Node ABI 127 not prebuilt.

## :bulb: Proposed solution

Support ABI 127. Fixes #42

## :gear: Release Notes

Added support for Node ABI 127 (NodeJS v22)

### Testing

None

### Reviewer Nudging

I never contributed before, so not sure what else needs to be changed to support Node ABI 127. Help would be greatly appreciated :) 👍 